### PR TITLE
Fix linting issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,4 @@ deps =
     flake8-html
     flake8-debugger
 commands =
-    flake8 --format=html --htmldir={toxinidir}/flake8 --doctests src tests setup.py {posargs}
+    flake8 --format=html --htmldir={toxinidir}/flake8 --doctests src setup.py {posargs}


### PR DESCRIPTION
... which arise with the new flake8 version.

`tests` is no longer a valid flake8 param, as it is no top level
directory.

As it is a subfolder of the `src` folder, it gets linted anyway.

flake8 is not run on Travis, but I leave it for now, as all Zope repos
get unified anyway, cf
https://github.com/zopefoundation/meta/tree/master/config

modified:   tox.ini