### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ z3c.objpath changes
 3.0 (unreleased)
 ================
 
-- Nothing changed yet.
+* Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 2.1 (2025-04-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 z3c.objpath changes
 *******************
 
-2.2 (unreleased)
+3.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -36,9 +35,6 @@ setup(
     author_email='faassen@startifact.com',
     url='https://github.com/zopefoundation/z3c.objpath',
     license='ZPL',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ long_description = (
 
 setup(
     name='z3c.objpath',
-    version='2.2.dev0',
+    version='3.0.dev0',
     description="Generate and resolve paths to to objects.",
     long_description=long_description,
     classifiers=[

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
